### PR TITLE
Fix StartLimitInterval systemd option name and location

### DIFF
--- a/sources/vault.service
+++ b/sources/vault.service
@@ -4,7 +4,6 @@ Documentation=https://www.vaultproject.io/docs/
 Requires=network-online.target
 After=network-online.target
 ConditionFileNotEmpty=/etc/vault/vault.hcl
-StartLimitIntervalSec=60
 
 [Service]
 User=vault
@@ -26,6 +25,7 @@ Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
 StartLimitBurst=3
+StartLimitInterval=60
 LimitNOFILE=65536
 
 [Install]


### PR DESCRIPTION
When starting the service on CentOS 7, one gets:

    systemd[1]: [/usr/lib/systemd/system/vault.service:7] Unknown lvalue 'StartLimitIntervalSec' in section 'Unit'

system.unit(5) man page does not indeed list such an option, in
constrast with systemd.service(5)

Moreover, the option is named StartLimitInterval in old (<246) systemd,
see https://github.com/systemd/systemd/commit/f0367da7d1a61ad698a55d17b5c28ddce0dc265a

We thus move the option in [Service] section and rename it to its old
name for RH7 compat.